### PR TITLE
Fix demo dataset path and add sample data

### DIFF
--- a/cat-facts.txt
+++ b/cat-facts.txt
@@ -1,0 +1,3 @@
+Cats sleep 70% of their lives.
+A group of cats is called a clowder.
+Cats have five toes on their front paws and four on their back paws.

--- a/demo.py
+++ b/demo.py
@@ -1,26 +1,27 @@
 from pathlib import Path
 
-p = Path("C:\Users\mtthw\Documents\GitHub\Test RAG\cat-facts.txt")
-for enc in ("utf-8", "utf-8-sig", "cp1252", "latin-1"):
-    try:
-        with p.open("r", encoding=enc) as f:
-            dataset = f.readlines()
-        break
-    except UnicodeDecodeError:
-        continue
-else:
+# Load dataset using a path relative to this file so it works cross-platform
+DATASET_PATH = Path(__file__).with_name("cat-facts.txt")
+
+def load_dataset(path: Path):
+    for enc in ("utf-8", "utf-8-sig", "cp1252", "latin-1"):
+        try:
+            with path.open("r", encoding=enc) as f:
+                return f.readlines()
+        except UnicodeDecodeError:
+            continue
     # last resort: replace undecodable bytes
-    with p.open("r", encoding="utf-8", errors="replace") as f:
-        dataset = f.readlines()
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        return f.readlines()
+
+try:
+    import ollama
+except ModuleNotFoundError as exc:
+    raise SystemExit("The 'ollama' package is required to run this demo.") from exc
 
 
-import ollama
-
-dataset = []
-with open('cat-facts.txt', 'r') as file:
-    dataset = file.readlines()
-    print(f'Loaded {len(dataset)} entries')
-    
+dataset = load_dataset(DATASET_PATH)
+print(f"Loaded {len(dataset)} entries")
 
 EMBEDDING_MODEL = 'hf.co/CompendiumLabs/bge-base-en-v1.5-gguf'
 LANGUAGE_MODEL = 'hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF'
@@ -30,38 +31,37 @@ LANGUAGE_MODEL = 'hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF'
 VECTOR_DB = []
 
 def add_chunk_to_database(chunk):
-  embedding = ollama.embed(model=EMBEDDING_MODEL, input=chunk)['embeddings'][0]
-  VECTOR_DB.append((chunk, embedding))
-
+    embedding = ollama.embed(model=EMBEDDING_MODEL, input=chunk)['embeddings'][0]
+    VECTOR_DB.append((chunk, embedding))
 
 for i, chunk in enumerate(dataset):
-  add_chunk_to_database(chunk)
-  print(f'Added chunk {i+1}/{len(dataset)} to the database')
+    add_chunk_to_database(chunk)
+    print(f'Added chunk {i+1}/{len(dataset)} to the database')
 
 def cosine_similarity(a, b):
-  dot_product = sum([x * y for x, y in zip(a, b)])
-  norm_a = sum([x ** 2 for x in a]) ** 0.5
-  norm_b = sum([x ** 2 for x in b]) ** 0.5
-  return dot_product / (norm_a * norm_b)
+    dot_product = sum(x * y for x, y in zip(a, b))
+    norm_a = sum(x ** 2 for x in a) ** 0.5
+    norm_b = sum(x ** 2 for x in b) ** 0.5
+    return dot_product / (norm_a * norm_b)
 
 def retrieve(query, top_n=3):
-  query_embedding = ollama.embed(model=EMBEDDING_MODEL, input=query)['embeddings'][0]
-  # temporary list to store (chunk, similarity) pairs
-  similarities = []
-  for chunk, embedding in VECTOR_DB:
-    similarity = cosine_similarity(query_embedding, embedding)
-    similarities.append((chunk, similarity))
-  # sort by similarity in descending order, because higher similarity means more relevant chunks
-  similarities.sort(key=lambda x: x[1], reverse=True)
-  # finally, return the top N most relevant chunks
-  return similarities[:top_n]
+    query_embedding = ollama.embed(model=EMBEDDING_MODEL, input=query)['embeddings'][0]
+    # temporary list to store (chunk, similarity) pairs
+    similarities = []
+    for chunk, embedding in VECTOR_DB:
+        similarity = cosine_similarity(query_embedding, embedding)
+        similarities.append((chunk, similarity))
+    # sort by similarity in descending order, because higher similarity means more relevant chunks
+    similarities.sort(key=lambda x: x[1], reverse=True)
+    # finally, return the top N most relevant chunks
+    return similarities[:top_n]
 
 input_query = input('Ask me a question: ')
 retrieved_knowledge = retrieve(input_query)
 
 print('Retrieved knowledge:')
 for chunk, similarity in retrieved_knowledge:
-  print(f' - (similarity: {similarity:.2f}) {chunk}')
+    print(f' - (similarity: {similarity:.2f}) {chunk}')
 
 instruction_prompt = f'''You are a helpful chatbot.
 Use only the following pieces of context to answer the question. Don't make up any new information:
@@ -69,15 +69,15 @@ Use only the following pieces of context to answer the question. Don't make up a
 '''
 
 stream = ollama.chat(
-  model=LANGUAGE_MODEL,
-  messages=[
-    {'role': 'system', 'content': instruction_prompt},
-    {'role': 'user', 'content': input_query},
-  ],
-  stream=True,
+    model=LANGUAGE_MODEL,
+    messages=[
+        {'role': 'system', 'content': instruction_prompt},
+        {'role': 'user', 'content': input_query},
+    ],
+    stream=True,
 )
 
 # print the response from the chatbot in real-time
 print('Chatbot response:')
 for chunk in stream:
-  print(chunk['message']['content'], end='', flush=True)
+    print(chunk['message']['content'], end='', flush=True)


### PR DESCRIPTION
## Summary
- load cat facts using a cross-platform path with encoding fallback
- exit with a helpful message when the `ollama` package is missing
- include a small `cat-facts.txt` dataset for the demo

## Testing
- `python demo.py <<'EOF'
Hello
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6898c236cdcc8323a9e9f2d5ca4c47f7